### PR TITLE
Support adding of rules from channel CLI

### DIFF
--- a/src/commands/addRuleCommand.js
+++ b/src/commands/addRuleCommand.js
@@ -1,0 +1,205 @@
+const JoinOps = require('../joinOperator');
+const DiscordHelper = require('../discordHelper');
+const RuleModel = require('../ruleModel');
+
+const nameParam = '-n';
+const targetRoleParam = '-r';
+const dependsOnParam = '-d';
+const joinParam = '-j';
+const whitelistRolesParam = '-w';
+const whitelistUsersParam = '-u';
+
+class AddRuleCommand {
+    constructor(settings) {
+        this._settings = settings;
+
+        this.name = "add";
+
+        // Because our command processor doesn't support this type of command parsing, we read the entirety of the command parameter
+        // as a string and perform special parsing afterwards.
+        this.params = [
+            { name: 'expression', isRequired: true, isSwitch: false, isGlob: true, position: 0 },
+        ];
+
+        this.helpText = `Usage: *${settings.command.longTriggerWord} ${this.name} \`-n rule_name\` \`-r role name\` \`-d role name 1, role name 2\` \`-j [and | or]\` \`-w role name 1, role name 2\` \`-u 123, 456\`*\n
+\`${nameParam}\`: Required; the name of the rule. No spaces.
+\`${targetRoleParam}\`: Required; the name of the role to be removed on rule match.
+\`${dependsOnParam}\`: Required: name of roles that the targeted role requires to exist to avoid removal. Separate roles with a comma.
+\`${joinParam}\`: Optional: how to join the dependent roles together; \`and\`: all roles must exist, \`or\`: at least one role must exist. Defaults to \`or\` if omitted.
+\`${whitelistRolesParam}\`: Optional: whitelisted role names on users that this rule will not apply to.
+\`${whitelistUsersParam}\`: Optional: whitelisted user IDs that this rule will not apply to.\n`;
+    }
+
+    async asyncHandler(channel, commandContext, discordClient, cmdProc) {
+        const unparsedCommand = commandContext.params['expression'];
+        const argTokens = unparsedCommand.split(/[\s]?(-[nrdjwu])\s/);
+
+        var currentMode = '';
+        var self = this;
+        var modeHandlers = {};
+        modeHandlers[nameParam] = function (t) {
+            if (self._verifySingleString(t)) {
+                return self._readSingleString(t);
+            }
+            return { error: 'value cannot be empty, contain spaces, or contain multiple entries' };
+        };
+        modeHandlers[targetRoleParam] = function (t) {
+            if (self._verifyMultiString(t)) {
+                return self._readSingleString(t);
+            }
+            return { error: 'value cannot be empty' };
+        };
+        modeHandlers[dependsOnParam] = function (t) {
+            if (self._verifyMultiString(t)) {
+                return self._readMultiString(t);
+            }
+            return { error: 'value cannot be empty or contain multiple entries' };
+        };
+        modeHandlers[joinParam] = function (t) {
+            const choices = ['and', 'or'];
+            if (self._verifyMultipleChoice(t, choices)) {
+                return self._readNormalizedString(t);
+            }
+            return { error: `value must be one of these: \`${choices.join(', ')}\`` };
+        };
+        modeHandlers[whitelistRolesParam] = function (t) {
+            if (self._verifyMultiString(t)) {
+                return self._readMultiString(t);
+            }
+            return { error: 'value cannot be empty' };
+        };
+        modeHandlers[whitelistUsersParam] = function (t) {
+            if (self._verifyMultiString(t)) {
+                return self._readMultiString(t);
+            }
+            return { error: 'value cannot be empty' };
+        };
+
+        var assignedParams = {};
+
+        for (var i = 0; i < argTokens.length; ++i) {
+            const token = argTokens[i];
+
+            // Dead token, probably leading whitespace
+            if (token === '' && currentMode === '') {
+                continue;
+            }
+
+            // Searching for a parameter
+            if (currentMode === '') {
+                const normalizedToken = token.toLowerCase();
+                if (modeHandlers.hasOwnProperty(normalizedToken)) {
+                    currentMode = normalizedToken;
+                }
+            }
+            else {
+                const results = modeHandlers[currentMode](token);
+                if (results.error) {
+                    channel.send(`Error for parameter: ${currentMode}: ${results.error}`);
+                    throw 'Failed to add rule.';
+                }
+                else {
+                    assignedParams[currentMode] = results;
+                }
+
+                currentMode = '';
+            }
+        }
+
+        // Verify we have all we need and back fill optionals
+        var errorLog = [];
+        this._assertRequiredProperty(assignedParams, nameParam, errorLog);
+        this._assertRequiredProperty(assignedParams, targetRoleParam, errorLog);
+        this._assertRequiredProperty(assignedParams, dependsOnParam, errorLog);
+        this._backfillOptionalProperty(assignedParams, joinParam, 'or');
+        this._backfillOptionalProperty(assignedParams, whitelistRolesParam, []);
+        this._backfillOptionalProperty(assignedParams, whitelistUsersParam, []);
+
+        if (errorLog.length > 0) {
+            errorLog.forEach(e => channel.send(e));
+        }
+        else {
+            // TODO: TEST ONLY
+            const rule = new RuleModel(assignedParams[nameParam],
+                                       assignedParams[targetRoleParam],
+                                       assignedParams[dependsOnParam],
+                                       assignedParams[joinParam],
+                                       assignedParams[whitelistUsersParam],
+                                       assignedParams[whitelistRolesParam]);
+
+            cmdProc.rulesData.addRule(rule);
+            cmdProc.rulesData.saveFile();
+
+            const outputIgnoreUsers = rule.whitelistByUserId.length > 0 ? rule.whitelistByUserId.join(',') : 'None';
+            const outputIgnoreRules = rule.whitelistByRoleName.length > 0 ? rule.whitelistByRoleName.join(',') : 'None';
+            const summary = `\nAdded new rule::
+Name: \`${rule.name}\`
+Role: [\`${rule.targetRole}\`]  ---depends-on--->  \`${rule.dependsOn.join(` ${JoinOps[rule.joinWith]} `)}\`
+Ignore Users: \`${outputIgnoreUsers}\`
+Ignore Roles: \`${outputIgnoreRules}\``;
+
+            channel.send(summary, { split: true });
+        }
+    }
+
+    _assertRequiredProperty(obj, propName, errLog) {
+        if (!obj.hasOwnProperty(propName)) {
+            errLog.push(`Missing required parameter: ${propName}`);
+        }
+    }
+
+    _backfillOptionalProperty(obj, propName, defaultIfMissing) {
+        if (!obj.hasOwnProperty(propName)) {
+            obj[propName] = defaultIfMissing;
+        }
+    }
+
+    _verifyMultipleChoice(token, choices) {
+        return choices.includes(token.trim().toLowerCase());
+    }
+
+    _verifySingleString(token) {
+        return this._verifySingleStringWithSpaces(token) && !token.includes(' ');
+    }
+
+    _verifySingleStringWithSpaces(token) {
+        if (!token) {
+            return false;
+        }
+
+        const trimmed = token.trim();
+        if (trimmed.length == 0) {
+            return false;
+        }
+
+        return !trimmed.includes(', ');
+    }
+
+    _verifyMultiString(token) {
+        if (!token) {
+            return false;
+        }
+
+        const trimmed = token.trim();
+        if (trimmed.length == 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    _readSingleString(token) {
+        return token.trim();
+    }
+
+    _readMultiString(token) {
+        const asTokens = token.split(',').map(t => t.trim());
+        return asTokens;
+    }
+
+    _readNormalizedString(token) {
+        return token.trim().toLowerCase();
+    }
+}
+
+module.exports = AddRuleCommand;

--- a/src/commands/helpCommand.js
+++ b/src/commands/helpCommand.js
@@ -14,6 +14,7 @@ class HelpCommand {
 \`\`\`Available commands:\n
 list: Lists rules or victims\n
 clean: Cleans up roles based on rules\n
+add: Adds a new rule
 \`\`\``;
     }
 

--- a/src/commands/helpCommand.js
+++ b/src/commands/helpCommand.js
@@ -12,7 +12,7 @@ class HelpCommand {
         // from each other.
         this.helpText = `Usage: *${settings.command.longTriggerWord} ${this.name}* [command_name]\n
 \`\`\`Available commands:\n
-list: Lists rules or victims\n
+list: Lists rules or targets\n
 clean: Cleans up roles based on rules\n
 add: Adds a new rule
 \`\`\``;

--- a/src/commands/listCommand.js
+++ b/src/commands/listCommand.js
@@ -9,17 +9,17 @@ class ListCommand {
 
         this.params = [
             { name: 'rules', isRequired: true, isSwitch: true, isGlob: false, position: 0 },
-            { name: 'victims', isRequired: true, isSwitch: true, isGlob: false, position: 0 }
+            { name: 'targets', isRequired: true, isSwitch: true, isGlob: false, position: 0 }
         ];
 
-        this.helpText = `Usage: *${settings.command.longTriggerWord} ${this.name}* [\`rules|victims\`]\n
+        this.helpText = `Usage: *${settings.command.longTriggerWord} ${this.name}* [\`rules|targets\`]\n
 \`rules\`: Shows all clean up rules\n
-\`victims\`: Shows all users that would have roles cleaned up under each defined rule. Note, this can be a large list!\n`;
+\`targets\`: Shows all users that would have roles cleaned up under each defined rule. Note, this can be a large list!\n`;
     }
 
     async asyncHandler(channel, commandContext, discordClient, cmdProc) {
         const showRules = commandContext.params['rules'];
-        const showVictims = commandContext.params['victims'];
+        const showTargets = commandContext.params['targets'];
 
         if (showRules === true) {
             const allRules = cmdProc.rulesData.rules;
@@ -33,7 +33,7 @@ class ListCommand {
 
             channel.send(`Currently configured rules:\n${mappedRules}`, { split: true });
         }
-        else if (showVictims === true) {
+        else if (showTargets === true) {
             const helper = new DiscordHelper(discordClient, this._settings);
             const allRules = cmdProc.rulesData.rules;
             const guild = await helper.getGuild();

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const RulesData = require("./rulesData");
 const HelpCommand = require('./commands/helpCommand');
 const ListCommand = require("./commands/listCommand");
 const CleanUpCommand = require("./commands/cleanUpCommand");
+const AddRuleCommand = require("./commands/addRuleCommand");
 
 const client = new Discord.Client();
 const settings = JSON.parse(fs.readFileSync("production.settings.json"));
@@ -17,7 +18,8 @@ const rulesData = new RulesData(settings.rulesFile);
 const cmdletDefinitions = [
     new HelpCommand(settings),
     new ListCommand(settings),
-    new CleanUpCommand(settings)
+    new CleanUpCommand(settings),
+    new AddRuleCommand(settings)
 ];
 
 const cmdProcessor = new CommandProcessor(rulesData, cmdletDefinitions, client, settings);
@@ -40,10 +42,13 @@ function executeCommand(fullCommandString, channel) {
             console.log(err);
 
             if (!_.isEmpty(settings.postLogsToChannelId)) {
-                const channel = await client.channels.fetch(settings.postLogsToChannelId)
-                if (channel) {
-                    channel.send(err.message);
+                const privateLogChannel = await client.channels.fetch(settings.postLogsToChannelId)
+                if (privateLogChannel) {
+                    privateLogChannel.send(err);
                 }
+            }
+            else {
+                channel.send(err);
             }
         });
 }

--- a/src/rulesData.js
+++ b/src/rulesData.js
@@ -4,7 +4,24 @@ const RuleModel = require("./ruleModel");
 
 class RulesData {
     constructor(rulesFilePath) {
+        this._savePath = rulesFilePath;
         this._loadRules(rulesFilePath);
+    }
+
+    addRule(ruleModel) {
+        if (!ruleModel) {
+            console.log("Cannot add undefined rule model");
+            return;
+        }
+
+        this.rules.push(ruleModel);
+    }
+
+    saveFile() {
+        const obj = { rules: this.rules };
+        const asJson = JSON.stringify(obj, null, 4)
+        fs.writeFileSync(this._savePath, asJson);
+        console.log(`Saved rules files to: ${this._savePath}`);
     }
 
     _tryCreateBlankFile(rulesFilePath) {


### PR DESCRIPTION
- Added new command: `add` to add rules with full parameter capability
- Revised CommandProcessor to fix globbing.
- Fixed issue attempting to print blank error strings on exceptions
- Printing errors to channel now either prints to executing channel (if `postLogsToChannelId` is blank) or uses the specified log channel.
- Added file saving to RulesData 
- Renamed `victims` to `targets` for `list` command, seemed more appropriate since that command doesn't apply rule checks.